### PR TITLE
Updated docs.ncsa.illinios.edu URLs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ More Documentation
 
    Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>
    Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>
-   :doc:`systems/icc`
+   icc/index
    ICRN <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>
    Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>
    Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ More Documentation
 
    Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>
    Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>
-   systems/icc/index
+   ICC <https://docs.ncsa.illinois.edu/systems/icc>
    ICRN <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>
    Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>
    Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,10 +9,10 @@ Computing Resources User Documentation
 
 The pages linked here are the official user documentation for the computing resource.  
 
-- `Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>`_ 
+- `Delta </systems/delta>`_ 
 - `Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>`_
 - `Illinois Campus Cluster (ICC) </systems/icc/>`_
-- `Illinois Computes Research Notebooks (ICRN) <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>`_
+- `Illinois Computes Research Notebooks (ICRN) </systems/icrn>`_
 - `Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>`_
 - `Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>`_
 - `Taiga & Granite <https://wiki.ncsa.illinois.edu/pages/viewpage.action?pageId=148538533>`_
@@ -48,10 +48,10 @@ More Documentation
    :caption: Resource Documentation
    :hidden:
 
-   Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>
+   Delta <https://docs.ncsa.illinois.edu/systems/delta>
    Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>
    ICC <https://docs.ncsa.illinois.edu/systems/icc>
-   ICRN <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>
+   ICRN <https://docs.ncsa.illinois.edu/systems/icrn>
    Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>
    Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>
    Taiga & Granite <https://wiki.ncsa.illinois.edu/pages/viewpage.action?pageId=148538533>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ More Documentation
 
    Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>
    Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>
-   systems/icc
+   systems/icc/index
    ICRN <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>
    Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>
    Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ More Documentation
 
    Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>
    Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>
-   ICC <https://campuscluster.illinois.edu/resources/docs/>
+   ICC </systems/icc/>
    ICRN <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>
    Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>
    Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,9 @@ The pages linked here are the official user documentation for the computing reso
 
 - `Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>`_ 
 - `Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>`_
-- `Illinois Campus Cluster (ICC) <https://campuscluster.illinois.edu/resources/docs/>`_
+- `Illinois Campus Cluster (ICC) </icc/>`_
+- `Illinois Campus Cluster (ICC) </icc/>`
+- :doc:`Illinois Campus Cluster (ICC) </icc/>`
 - `Illinois Computes Research Notebooks (ICRN) <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>`_
 - `Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>`_
 - `Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>`_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ More Documentation
 
    Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>
    Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>
-   ICC </systems/icc/>
+   ICC <icc>
    ICRN <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>
    Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>
    Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ More Documentation
 
    Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>
    Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>
-   icc/index
+   systems/icc/index
    ICRN <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>
    Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>
    Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ More Documentation
 
    Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>
    Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>
-   /systems/icc
+   systems/icc
    ICRN <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>
    Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>
    Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,9 +11,7 @@ The pages linked here are the official user documentation for the computing reso
 
 - `Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>`_ 
 - `Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>`_
-- `Illinois Campus Cluster (ICC) </icc/>`_
-- `Illinois Campus Cluster (ICC) </icc/>`
-- :doc:`Illinois Campus Cluster (ICC) </icc/>`
+- `Illinois Campus Cluster (ICC) </systems/icc/>`_
 - `Illinois Computes Research Notebooks (ICRN) <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>`_
 - `Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>`_
 - `Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>`_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ More Documentation
 
    Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>
    Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>
-   systems/icc/index
+   :doc:`systems/icc`
    ICRN <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>
    Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>
    Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ More Documentation
 
    Delta <https://ncsa-delta-doc.readthedocs-hosted.com/en/latest/>
    Hydro <https://ncsa-hydro-documentation.readthedocs-hosted.com/en/latest/>
-   ICC <icc>
+   /systems/icc
    ICRN <https://ncsa-icrn-docs.readthedocs-hosted.com/en/latest>
    Nightingale <https://ncsa-nightingale.readthedocs-hosted.com>
    Radiant <https://wiki.ncsa.illinois.edu/display/PUBCR/User+Documentation+Directory>


### PR DESCRIPTION
Updated Delta, ICC, and ICRN URLs to docs.ncsa.illinois.edu... I'll submit this pull request/merge once the ICC RTD page is public (should be Tuesday or Wednesday). In the meantime, the current URLs redirect to the new ones so no impact to user access to the correct docs from this page.