### PR TITLE
Adding cookies banner

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -6,3 +6,17 @@
 body > div > nav > div > div.wy-side-nav-search > a:hover{
     background: #2980b9 !important;
 }
+
+
+/* custom styling for 'about cookies' banner in footer */
+#cookie-button {
+    cursor: pointer;
+    color:  #FF5F05;
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+}
+
+#cookie-button:hover {
+    color: #13294B;
+}

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -1,0 +1,9 @@
+<!--This adds the About Cookies button to the footer-->
+
+{% extends '!footer.html' %}
+
+{% block extrafooter %} {{super}}
+      <!-- OneTrust Cookies Settings button start -->
+      <button id="cookie-button" class="ot-sdk-show-settings">About Cookies</button>
+      <!-- OneTrust Cookies Settings button end -->
+{% endblock %}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,11 @@
+<!--This adds the script for the OneTrust cookies banner to the <head> of each page-->
+
+{% extends '!layout.html' %}
+{% block extrahead %}
+   <!-- OneTrust Cookies Consent Notice start, illinois.edu -->
+      <script src="https://onetrust.techservices.illinois.edu/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="26be7d61-2017-4ea7-8a8b-8f1704889763"></script>
+      <script type="text/javascript">
+      function OptanonWrapper() { }
+      </script>
+   <!-- OneTrust Cookies Consent Notice end, illinois.edu -->
+{% endblock %}


### PR DESCRIPTION
This PR adds the UIUC cookies banner (and About Cookies button) to the doc set so that Google Analytics can be set up on the docs.ncsa.illinois.edu pages.