### PR TITLE
Index page changes

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,14 +29,8 @@ The pages linked here are the official user documentation for the storage resour
 - `Jade </systems/jade>`_
 - `Taiga </systems/taiga>`_
 
-More Documentation
-===================
-
-.. note::
-   This section is in development, pages will be added as they are created.
-
 Common System Documentation
------------------------------
+===================
 
 Addititional user documentation on topics common across one or more NCSA computing resource.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,21 +62,24 @@ Addititional user documentation on topics common across one or more NCSA computi
    help
 
 .. toctree::
-   :caption: Resource Documentation
+   :caption: Computing Resources
    :hidden:
 
    Delta <https://docs.ncsa.illinois.edu/systems/delta>
-   Granite <https://docs.ncsa.illinois.edu/systems/granite/>
    Hydro <https://docs.ncsa.illinois.edu/systems/hydro>
    ICC <https://docs.ncsa.illinois.edu/systems/icc>
    ICRN <https://docs.ncsa.illinois.edu/systems/icrn>
    Illinois HTC <https://docs.ncsa.illinois.edu/systems/iccp-htc>
-   Jade <https://docs.ncsa.illinois.edu/systems/jade/>
    Nightingale <https://docs.ncsa.illinois.edu/systems/nightingale>
    Radiant <https://docs.ncsa.illinois.edu/systems/radiant>
+
+.. toctree::
+   :caption: Storage Resources
+   :hidden:
+
+   Granite <https://docs.ncsa.illinois.edu/systems/granite/>
+   Jade <https://docs.ncsa.illinois.edu/systems/jade/>
    Taiga <https://docs.ncsa.illinois.edu/systems/taiga/>
-
-
 
 .. toctree::
    :caption: More Documentation


### PR DESCRIPTION
Removes "More Documentation" heading to flatten index page. 

Also splits "Resource Documentation" heading in left sidebar into "Computing Resources" and "Storage Resources"; this change was requested by JD.

RTD build: https://docs.ncsa.illinois.edu/en/proposed_changes/index.html

