### PR TITLE
Updating Consulting Services section in Getting Help

### DIFF
--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -52,6 +52,6 @@ Illinois researchers can request research consulting services from NCSA experts 
 These services can help with things like optimizing and modernizing existing code, visual data analysis, finding research solutions to complex questions, and much more! 
 For more details, visit `Illinois Computes - Find Support <https://computes.illinois.edu/support/>`_.
 
-Illinois Computes requests are submitted through the `NCSA XRAS portal <https://xras-submit.ncsa.illinois.edu/>`_. After you log in with your NCSA username and password, select **Start a New Illinois Computes Program Submission** and select **NCSA Consulting Services** as the resource in the form.
+Illinois Computes requests are submitted through the `NCSA XRAS portal <https://xras-submit.ncsa.illinois.edu/>`_. After you log in with your NCSA username and password, select **Start a New Illinois Computes Program Submission** and then select **NCSA Consulting Services** as the resource in the form.
 
 |

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -52,6 +52,6 @@ Illinois researchers can request research consulting services from NCSA experts 
 These services can help with things like optimizing and modernizing existing code, visual data analysis, finding research solutions to complex questions, and much more! 
 For more details, visit `Illinois Computes - Find Support <https://computes.illinois.edu/support/>`_.
 
-Illinois Computes requests are submitted through the NCSA XRAS portal. Follow this guide on `how to submit a new XRAS request <https://docs.ncsa.illinois.edu/en/latest/allocations/xras-new.html>`_ to get started; after you log in, select **Start a New Illinois Computes Program Submission** and in the form, select **NCSA Consulting Services** as the resource.
+Illinois Computes requests are submitted through the `NCSA XRAS portal <https://xras-submit.ncsa.illinois.edu/>`_. After you log in with your NCSA username and password, select **Start a New Illinois Computes Program Submission** and select **NCSA Consulting Services** as the resource in the form.
 
 |

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -48,7 +48,9 @@ You will receive email correspondence as your ticket is worked on, please respon
 Consulting Services
 ------------------------
 
-Illinois researchers can `request research consulting services <https://computes.illinois.edu/submit-a-request/>`_ from NCSA experts through the Illinois Computes program. 
-These services can help with things like optimizing and modernizing existing code, visual data analysis, finding research solutions to complex questions, and much more! For more details, visit the `Illinois Computes Expertise & User Support <https://computes.illinois.edu/expertise-user-support/>`_ page.
+Illinois researchers can request research consulting services from NCSA experts through the Illinois Computes program. 
+These services can help with things like optimizing and modernizing existing code, visual data analysis, finding research solutions to complex questions, and much more! 
+For more details, visit `Illinois Computes - What's Available <https://computes.illinois.edu/about/whats_available/>`_.
+Illinois Computes requests are submitted through the NCSA XRAS portal; follow this guide on `how to submit a new XRAS request <https://docs.ncsa.illinois.edu/en/latest/allocations/xras-new.html>`_ and select **Start a New Illinois Computes Program Submission** to get started.
 
 |

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -51,6 +51,7 @@ Consulting Services
 Illinois researchers can request research consulting services from NCSA experts through the Illinois Computes program. 
 These services can help with things like optimizing and modernizing existing code, visual data analysis, finding research solutions to complex questions, and much more! 
 For more details, visit `Illinois Computes - What's Available <https://computes.illinois.edu/about/whats_available/>`_.
+
 Illinois Computes requests are submitted through the NCSA XRAS portal; follow this guide on `how to submit a new XRAS request <https://docs.ncsa.illinois.edu/en/latest/allocations/xras-new.html>`_ and select **Start a New Illinois Computes Program Submission** to get started.
 
 |

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -50,8 +50,8 @@ Consulting Services
 
 Illinois researchers can request research consulting services from NCSA experts through the Illinois Computes program. 
 These services can help with things like optimizing and modernizing existing code, visual data analysis, finding research solutions to complex questions, and much more! 
-For more details, visit `Illinois Computes - What's Available <https://computes.illinois.edu/about/whats_available/>`_.
+For more details, visit `Illinois Computes - Find Support <https://computes.illinois.edu/support/>`_.
 
-Illinois Computes requests are submitted through the NCSA XRAS portal; follow this guide on `how to submit a new XRAS request <https://docs.ncsa.illinois.edu/en/latest/allocations/xras-new.html>`_ and select **Start a New Illinois Computes Program Submission** to get started.
+Illinois Computes requests are submitted through the NCSA XRAS portal. Follow this guide on `how to submit a new XRAS request <https://docs.ncsa.illinois.edu/en/latest/allocations/xras-new.html>`_ to get started; after you log in, select **Start a New Illinois Computes Program Submission** and in the form, select **NCSA Consulting Services** as the resource.
 
 |


### PR DESCRIPTION
Updated the Consulting Services section of Getting Help. The IL computes site was redesigned and old links no longer worked.

RTD build: https://docs.ncsa.illinois.edu/en/proposed_changes/help.html