### PR TITLE
Updates to help.rst

### DIFF
--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -18,12 +18,29 @@ When you submit a support request, please let us know what you tried, and what h
 
 .. _general-support:
 
-General Resource Support
----------------------------
+General Resource Support - NCSA Support Help Center
+------------------------------------------------------
+
+Go to the `NCSA Support Help Center <http://help.ncsa.illinois.edu>`_ for assistance with questions or issues not answered by the documentation. Powered by Jira Service Manager (JSM), in this new tool you can:
+
+- Search knowledge base articles to resolve common issues faster.
+- Submit help request tickets.
+- Monitor the status of your tickets.
+- Respond to NCSA staff as they work to resolve your tickets.
+
+Refer to the `JSM User Job Aid <https://docs.ncsa.illinois.edu/en/latest/_static/JSMUsersJobAid.pdf>`_ for information on how to navigate the help center.
 
 .. raw:: html
    
-   <p><b>Submit a support request</b> by emailing <a href="mailto:help@ncsa.illinois.edu">help@ncsa.illinois.edu</a>. Your email will initiate a ticket that NCSA staff will use to help you.</p>
+   <p>The <a href="http://help.ncsa.illinois.edu">NCSA Support Help Center</a> is the preferred method to submit requests. However, if you run into problems using it, you can still email <a href="mailto:help@ncsa.illinois.edu">help@ncsa.illinois.edu</a> for support. Expand the following section for guidelines on sending email requests so that NCSA staff can efficiently address them.</p>
+
+Email Support Request Guidelines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. raw:: html
+
+   <details>
+   <summary><a><b>Email support request guidelines</b> <i>(click to expand/collapse)</i></a></summary>
 
 **To help NCSA staff efficiently address your request, in your initial email, please include:**
 
@@ -44,6 +61,12 @@ General Resource Support
 **If you have multiple, unrelated issues, please create a separate ticket for each by sending separate emails.**
 
 You will receive email correspondence as your ticket is worked on, please respond to any questions that are asked.
+
+.. raw:: html
+
+   </details>
+
+|
 
 Consulting Services
 ------------------------


### PR DESCRIPTION
Updated help.rst 'general support' to point to new JSM help center. Kept info about email as option if users have issue using the help center but the help center is clearly described as the preferred method.