### PR TITLE
Landing page updates and update to the group management page

### DIFF
--- a/docs/source/account-mgmt/group-mgmt.rst
+++ b/docs/source/account-mgmt/group-mgmt.rst
@@ -6,6 +6,8 @@ Group/Project Member Management
 .. warning::
    To manage a project that was awarded via **ACCESS**, go to `ACCESS Allocations <https://allocations.access-ci.org/>`_.
 
+   To manage users in a **Campus Cluster** project, go to the `Campus Cluster Investor Portal <https://campuscluster.illinois.edu/investor/>`_.
+
 You use the `NCSA Group Management Tool <https://internal.ncsa.illinois.edu/mis/groups/>`_ to add and remove group members, invite new members to your group, and add delegates.
 
 Your NCSA system allocation likely uses "project" to describe your allocation, for the purposes of the group management tool, "project" and "group" are interchangeable; this page will use "group". 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,24 +74,8 @@ Addititional user documentation on topics common across two or more NCSA resourc
    :hidden:
 
    training
+   allocations/index
    help
-
-.. toctree::
-   :hidden:
-   :caption: Allocations
-
-   Resources Summary <allocations/index>
-   XRAS - Request a New Allocation <allocations/xras-new>
-   XRAS - Request an Extension or Supplement <allocations/xras-renew>
-   NCSA Identity Managament <account-mgmt/identity-mgmt>
-   Project/Group Management <account-mgmt/group-mgmt>
-
-.. toctree::
-   :caption: Common Documentation
-   :hidden:
-
-   common/transfer
-   common/relocate-conda-directory
 
 .. toctree::
    :caption: Computing Resources
@@ -115,5 +99,11 @@ Addititional user documentation on topics common across two or more NCSA resourc
    Harbor <https://docs.ncsa.illinois.edu/systems/harbor/>
    Jade <https://docs.ncsa.illinois.edu/systems/jade/>
    Taiga <https://docs.ncsa.illinois.edu/systems/taiga/>
+
+.. toctree::
+   :caption: More Documentation
+   :hidden:
+
+   common/index
 
 |

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,19 @@ The pages linked here are the official user documentation for the storage resour
 - `Jade </systems/jade>`_
 - `Taiga </systems/taiga>`_
 
+NCSA Allocations and Identity Management
+========================================
+
+Documentation that summarizes allocation information for NCSA resources and how to manage your NCSA identity and groups.
+
+- :ref:`Resources Summary <allocations>`
+- :ref:`by-resource`
+- :ref:`by-method`
+- :ref:`xras-new`
+- :ref:`xras-renew`
+- :ref:`ncsa-identity`
+- :ref:`group-mgmt`
+
 Common System Documentation
 ===============================
 
@@ -61,8 +74,24 @@ Addititional user documentation on topics common across two or more NCSA resourc
    :hidden:
 
    training
-   allocations/index
    help
+
+.. toctree::
+   :hidden:
+   :caption: Allocations
+
+   Resources Summary <allocations/index>
+   XRAS - Request a New Allocation <allocations/xras-new>
+   XRAS - Request an Extension or Supplement <allocations/xras-renew>
+   NCSA Identity Managament <account-mgmt/identity-mgmt>
+   Project/Group Management <account-mgmt/group-mgmt>
+
+.. toctree::
+   :caption: Common Documentation
+   :hidden:
+
+   common/transfer
+   common/relocate-conda-directory
 
 .. toctree::
    :caption: Computing Resources
@@ -87,8 +116,4 @@ Addititional user documentation on topics common across two or more NCSA resourc
    Jade <https://docs.ncsa.illinois.edu/systems/jade/>
    Taiga <https://docs.ncsa.illinois.edu/systems/taiga/>
 
-.. toctree::
-   :caption: More Documentation
-   :hidden:
-
-   common/index
+|


### PR DESCRIPTION
- Added an additional info to the warning at the top of the group management page directing Campus Cluster users to the Investor Portal. RTD build: https://docs.ncsa.illinois.edu/en/proposed_changes/account-mgmt/group-mgmt.html#group-mgmt
- Added links to the Allocations, Identity Management, and Group Management pages to the landing page. RTD build: https://docs.ncsa.illinois.edu/en/proposed_changes/index.html

There are additional left nav updates that are planned for these pages, but I'm going to save those for the major tiles update that I hope to have implemented next week.