### PR TITLE
Theme updates to address RTD addons update and more

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # Defining the exact version will make sure things don't break
 #sphinx<6
-sphinx-rtd-theme==2.1.0rc2
+sphinx-rtd-theme==3.0.0
 
 # Adding tabs extension
 sphinx-tabs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # Defining the exact version will make sure things don't break
 #sphinx<6
-sphinx-rtd-theme>1.2
+sphinx-rtd-theme==2.1.0rc2
 
 # Adding tabs extension
 sphinx-tabs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # Defining the exact version will make sure things don't break
 #sphinx<6
-sphinx-rtd-theme==3.0.0
+sphinx-rtd-theme==2.1.0rc2
 
 # Adding tabs extension
 sphinx-tabs

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -10,10 +10,12 @@
       {% endif %}
       <!-- Adding GitHub link end -->
 
-      <!-- Adding NCSA/UIUC blurb start -->
-      <p><a href="https://ncsa.illinois.edu">NCSA</a> is an Illinois Research Institute on the <a href="https://illinois.edu">University of Illinois Urbana-Champaign</a> campus.</p>
-      <!-- Adding NCSA/UIUC blurb end -->
       <!-- OneTrust Cookies Settings button start -->
       <button id="cookie-button" class="ot-sdk-show-settings">About Cookies</button>
       <!-- OneTrust Cookies Settings button end -->
+
+      <!-- Adding NCSA/UIUC blurb start -->
+      <p><a href="https://ncsa.illinois.edu">NCSA</a> is an Illinois Research Institute on the <a href="https://illinois.edu">University of Illinois Urbana-Champaign</a> campus.</p>
+      <!-- Adding NCSA/UIUC blurb end -->
+      
 {% endblock %}

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -3,6 +3,13 @@
 {% extends '!footer.html' %}
 
 {% block extrafooter %} {{super}}
+     <!-- Adding GitHub link start-->
+      {% if display_github %}
+          <a href="https://github.com/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst">
+          View on GitHub.</a>
+      {% endif %}
+      <!-- Adding GitHub link end -->
+
       <!-- Adding NCSA/UIUC blurb start -->
       <p><a href="https://ncsa.illinois.edu">NCSA</a> is an Illinois Research Institute on the <a href="https://illinois.edu">University of Illinois Urbana-Champaign</a> campus.</p>
       <!-- Adding NCSA/UIUC blurb end -->

--- a/docs/source/allocations/by-resource.rst
+++ b/docs/source/allocations/by-resource.rst
@@ -33,7 +33,7 @@ There are four ways to request an allocation on Delta, they are listed below in 
 DeltaAI
 ---------------
 
-Coming soon! DeltaAI is currently in the early access period, which helps NCSA test the system’s functionality and performance. 
+Coming soon! DeltaAI is currently in pre-production. 
 
 .. _allocate-granite:
 

--- a/docs/source/common/transfer.rst
+++ b/docs/source/common/transfer.rst
@@ -129,8 +129,8 @@ WinSCP
      - `Nightingale node hostnames <https://docs.ncsa.illinois.edu/systems/nightingale/en/latest/user_guide/accessing.html#node-hostnames>`_
 
    c. **Port number**: 22
-   d. **User name**: Your username for the associated NCSA system.
-   e. **Password**: Your password for the associated NCSA system.
+   d. **User name**: The username you use to log in to the system whose hostname you entered.
+   e. **Password**: The password you use to log in to the system whose hostname you entered.
 
    ICC example:
 
@@ -161,8 +161,8 @@ Cyberduck
      - `ICC DTN node hostname <https://docs.ncsa.illinois.edu/systems/icc/en/latest/user_guide/storage_data.html#cli-dtn-nodes>`_
      - `Nightingale node hostnames <https://docs.ncsa.illinois.edu/systems/nightingale/en/latest/user_guide/accessing.html#node-hostnames>`_
    c. **Port**: 22
-   d. **Username**: Your username for the associated NCSA system.
-   e. **Password**: Your password for the associated NCSA system. 
+   d. **Username**: The username you use to log in to the system whose hostname you entered.
+   e. **Password**: The password you use to log in to the system whose hostname you entered.
 
    ICC example:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,29 @@ project = 'NCSA Documentation Hub'
 copyright = '2023, University of Illinois'
 author = 'University of Illinois'
 
+# RTD recommended config file additions
+
+import os
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
+# Restoring GitHub link
+
+html_context = {
+    "display_github": True, # Integrate GitHub
+    "github_user": "ncsa", # Username
+    "github_repo": "ncsa_system_documentation", # Repo name
+    "github_version": os.environ.get("READTHEDOCS_GIT_IDENTIFIER"),  # Version
+    "conf_py_path": "/docs/source/", # Path in the checkout to the docs root
+}
+
 # -- General configuration
 
 extensions = [
@@ -51,6 +74,7 @@ html_logo = "images/BlockI-NCSA-Full-Color-RGB_border4.png"
 html_theme_options = {
      'logo_only': False,
      'display_version': False,
+     'flyout_display': 'attached',
  }
 
 # -- Change page title


### PR DESCRIPTION
These theme changes adjust for the 10/7 RTD Addons Update.
- Adds back the bottom-left flyout menu.
- Adds back the top-right Documentation Hub link.
- Adds 'View on GitHub' to the footer because, per RTD support, it has been removed from the flyout menu and there are no plans to add it back.

Also updated username and password description wording in WinSCP and Cyberduck sections of common transfer page to address a user comment.

RTD build: https://docs.ncsa.illinois.edu/en/proposed_changes/index.html

