### PR TITLE
fixing google analytics

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,6 @@ sphinx-copybutton
 
 #Adding sphinx-design extension
 sphinx-design
+
+#Adding googleanalytics extension
+sphinxcontrib-googleanalytics

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ extensions = [
     'sphinx_tabs.tabs',
     'sphinx_copybutton',
     'sphinx_design',
+    'sphinxcontrib.googleanalytics',
 ]
 
 intersphinx_mapping = {
@@ -79,3 +80,7 @@ html_theme_options = {
 
 # -- Change page title
 html_title = 'UIUC NCSA User Documentation'
+
+
+# -- Google Analytics ID
+googleanalytics_id = 'G-JG0GFE04G8'


### PR DESCRIPTION
Installs sphinxcontrib-googleanalytics (https://pypi.org/project/sphinxcontrib-googleanalytics/#description) extension to fix google analytics. Google analytics is no longer a built-in option to RTD builds. This is the extension recommended by RTD support.